### PR TITLE
Just a small typo fix..

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Notice there's a stop icon ![numix-stop](http://i.imgur.com/nEg3PPh.png) in the 
 - Ubuntu (Installing the missing dependencies)
     - Install what you can with apt-get
 
-            $ sudo apt-get install bash libav-tools imagemagick x11-xserver-utils xdotool wininfo wmctrl python-gobject pyhon-cairo xdg-utils
+            $ sudo apt-get install bash libav-tools imagemagick x11-xserver-utils xdotool wininfo wmctrl python-gobject python-cairo xdg-utils
             $ sudo ln -s /usr/bin/avconv /usr/bin/ffmpeg
     - Look for **Download "yad"** at [yad](http://www.ubuntuupdates.org/package/webupd8/trusty/main/base/yad), click the 32 bit or 64 bit version and let Software Center install it.
     - You're ready to install Silentcast using the Any Linux Distro method above.


### PR DESCRIPTION
Fixed typo in the `python-cairo` package name.
