### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,22 +183,20 @@ Notice there's a stop icon ![stop1.png](stop1.png) in the Notification Area befo
     - Without an AUR helper, just [Download silentcast.tar.gz from aur.archlinux.org](https://aur.archlinux.org/packages/si/silentcast/silentcast.tar.gz), extract, and do `makepkg -si` from the extracted directory. This will do exactly the same thing as an AUR helper would do for installation, but you will have to keep track of updates yourself. **Uninstall** with `sudo pacman -R silentcast`  
     
 - **Ubuntu Linux Full Install**  
-    - For 14.04 and 12.04 run the following commands to add the needed PPA/repositories (If the PPA/repositories are out of date or for older versions of Ubuntu follow one of the "Any Linux Distro" instructions): 
+    - For 14.04 and 12.04 run the following commands to install Silentcast (If the PPA/repositories are out of date or for older versions of Ubuntu follow one of the "Any Linux Distro" instructions): 
      
-            $ sudo add-apt-repository ppa:jon-severinsson/ffmpeg
-            $ sudo add-apt-repository ppa:webupd8team/y-ppa-manager  
             $ sudo add-apt-repository ppa:sethj/silentcast  
             $ sudo apt-get update
             $ sudo apt-get install silentcast  
             
        Or run the following, condensed, command:  
        
-            $ sudo add-apt-repository ppa:jon-severinsson/ffmpeg && sudo add-apt-repository ppa:webupd8team/y-ppa-manager && sudo add-apt-repository ppa:sethj/silentcast && sudo apt-get update && sudo apt-get install silentcast  
+            $ sudo add-apt-repository ppa:sethj/silentcast && sudo apt-get update && sudo apt-get install silentcast  
             
        - **Uninstall**  
        Run `sudo apt-get remove silentcast`. You can then remove the PPAs with `sudo add-apt-repository -r` like so:  
        
-                $ sudo add-apt-repository -r ppa:jon-severinsson/ffmpeg && sudo add-apt-repository -r ppa:webupd8team/y-ppa-manager && sudo add-apt-repository -r ppa:sethj/silentcast
+                $ sudo add-apt-repository -r ppa:sethj/silentcast && sudo apt-get update
 
 ###Launch Methods
 


### PR DESCRIPTION
I've patched the application to avconv for Ubuntu using quilt so ffmpeg is no longer needed and the webupd8 team has generously let me copy their yad package into my PPA, so theirs isn't needed anymore.  `apt-get update` should be run after removing a PPA so our sources are up to date.
