### PR TITLE
Add support for Pantheon Desktop used in Elementary OS

### DIFF
--- a/genffcom
+++ b/genffcom
@@ -235,9 +235,9 @@ Click the stop icon in the Notification Area" \
 (($? != 0)) && exit 1 #Cancel was clicked
 
 ffmpeg -f x11grab -s '$w'x'$h' -r '$fps' -i :0.0+'$x','$y' -c:v ffvhuff -an -y '"$ffcom_dir"'/temp.mkv & ffmpegPID=$!
-if [ "$XDG_CURRENT_DESKTOP" = "Unity"  ]
+if [ "$XDG_CURRENT_DESKTOP" = "Unity" -o "$XDG_CURRENT_DESKTOP" = "Pantheon"  ]
 then
-        echo "Unity detected, switching indicators..."
+        echo "Unity or Pantheon detected, switching indicators..."
 	python '"$py_script_dir"'/unity_indicator.py '$1'
 else
     yad --notification --image="'"$py_script_dir"'/stop'$1'.png" --text="'$1'"


### PR DESCRIPTION
Support for [Pantheon Desktop](https://wiki.archlinux.org/index.php/Pantheon) used in [Elementary OS](http://elementaryos.org/).
It used the same script to create the Tray icon as The Unity desktop used.
