### PR TITLE
Added plasma 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Notice there's a stop icon ![stop1.png](stop1.png) in the Notification Area befo
                 $ sudo ln -s /usr/bin/avconv /usr/bin/ffmpeg
         - Look for **Download "yad"** at [yad](http://www.ubuntuupdates.org/package/webupd8/trusty/main/base/yad),
        click the 32 bit or 64 bit version and let Software Center install it.
+       - Plasma 5 users will also need the `gir1.2-gtk-3.0` and `gir1.2-appindicator3-0.1` packages.
 
     - Fedora
         - If running Gnome, install [Topicons](https://extensions.gnome.org/extension/495/topicons/)
@@ -184,7 +185,7 @@ Notice there's a stop icon ![stop1.png](stop1.png) in the Notification Area befo
 
 - **Ubuntu Linux Full Install**  
     - For supported releases run the following commands to install Silentcast (If the PPA/repositories are out of date or for older versions of Ubuntu follow one of the "Any Linux Distro" instructions):
-     
+
             $ sudo add-apt-repository ppa:sethj/silentcast  
             $ sudo apt-get update
             $ sudo apt-get install silentcast  

--- a/genffcom
+++ b/genffcom
@@ -235,9 +235,9 @@ Click the stop icon in the Notification Area" \
 (($? != 0)) && exit 1 #Cancel was clicked
 
 ffmpeg -f x11grab -s '$w'x'$h' -r '$fps' -i '${DISPLAY:-\:0.0}'+'$x','$y' -c:v ffvhuff -an -y '"$ffcom_dir"'/temp.mkv & ffmpegPID=$!
-if [ "$XDG_CURRENT_DESKTOP" = "Unity" -o "$XDG_CURRENT_DESKTOP" = "Pantheon"  ]
+if [ "$XDG_CURRENT_DESKTOP" = "Unity" -o "$XDG_CURRENT_DESKTOP" = "Pantheon" -o "$KDE_SESSION_VERSION" = "5" ]
 then
-        echo "Unity or Pantheon detected, switching indicators..."
+        echo "Unity, Pantheon, or Plasma 5 detected. Switching indicators..."
 	python '"$py_script_dir"'/unity_indicator.py '$1'
 else
     yad --notification --image="'"$py_script_dir"'/stop'$1'.png" --text="'$1'"

--- a/unity_indicator.py
+++ b/unity_indicator.py
@@ -12,25 +12,26 @@ args = parser.parse_args()
 class IndicatorSilentcast:
     def __init__(self):
         self.indicator = appindicator.Indicator.new_with_path (
-                "silentcast", 
+                "silentcast",
                 "stop{}".format(args.silentcast_number),
                 appindicator.IndicatorCategory.APPLICATION_STATUS,
                 os.path.dirname(os.path.realpath(__file__)))
         self.indicator.set_status (appindicator.IndicatorStatus.ACTIVE)
-        
+
         self.menu = Gtk.Menu()
-        
+
         doneItem = Gtk.MenuItem("Done")
         doneItem.connect("activate", self.finishRecording)
         doneItem.show()
         self.menu.append(doneItem)
-        
+
         self.menu.show()
         self.indicator.set_menu(self.menu)
-        
+
+
     def finishRecording(self, widget):
             Gtk.main_quit()
-            
+
 def main():
     Gtk.main()
     exit(0)


### PR DESCRIPTION
Plasma 5 made some changes to how indicators work and yad hasn't updated their notification system to support it. Until then fallback to using the GTK AppIndicator created for Unity and Pantheon. Note that his will require some other dependencies on KDE systems, but atm I see no way around that.